### PR TITLE
LP Detail: add support for optional block height

### DIFF
--- a/src/lib/LPDetail.svelte
+++ b/src/lib/LPDetail.svelte
@@ -4,6 +4,7 @@
 
   export let address = null;
   export let pool = null;
+  export let height = null;
   export let goBack;
   export let runePrice;
   export let assetPrices;
@@ -14,7 +15,7 @@
   let error = null;
   let showMore = false;
 
-  const API_DOMAIN = import.meta.env.VITE_API_DOMAIN || 'https://thornode.ninerealms.com';
+  const API_DOMAIN = import.meta.env.VITE_API_DOMAIN || 'https://thornode-archive.ninerealms.com';
 
   const assetLogos = {
     'BTC.BTC': '/assets/coins/bitcoin-btc-logo.svg',
@@ -62,8 +63,14 @@
   async function loadLPData() {
     loading = true;
     error = null;
+
+    let url = `${API_DOMAIN}/thorchain/pool/${pool}/liquidity_provider/${address}`;
+    if (height) {
+      url += `?height=${height}`;
+    }
+
     try {
-      const response = await axios.get(`${API_DOMAIN}/thorchain/pool/${pool}/liquidity_provider/${address}`);
+      const response = await axios.get(url);
       lpData = response.data;
 
       // Divide deposit and redeem values by 1e8
@@ -193,7 +200,11 @@
         
         <!-- Total Value Card -->
         <div class="total-value">
-          <span class="total-label">Total Value</span>
+          {#if height}
+            <span class="total-label">Total Value (as of height {height})</span>
+          {:else}
+            <span class="total-label">Total Value</span>
+          {/if}
           <span class="total-amount">
             {formatUSD((lpData.rune_redeem_value * runePrice) + (lpData.asset_redeem_value * assetPrices[pool]))}
           </span>

--- a/src/lib/LPDetail.svelte
+++ b/src/lib/LPDetail.svelte
@@ -15,7 +15,8 @@
   let error = null;
   let showMore = false;
 
-  const API_DOMAIN = import.meta.env.VITE_API_DOMAIN || 'https://thornode-archive.ninerealms.com';
+  const API_DOMAIN = import.meta.env.VITE_API_DOMAIN || 'https://thornode.ninerealms.com';
+  const ARCHIVE_DOMAIN = 'https://thornode-archive.ninerealms.com';
 
   const assetLogos = {
     'BTC.BTC': '/assets/coins/bitcoin-btc-logo.svg',
@@ -64,7 +65,8 @@
     loading = true;
     error = null;
 
-    let url = `${API_DOMAIN}/thorchain/pool/${pool}/liquidity_provider/${address}`;
+    const domain = height ? ARCHIVE_DOMAIN : API_DOMAIN;
+    let url = `${domain}/thorchain/pool/${pool}/liquidity_provider/${address}`;
     if (height) {
       url += `?height=${height}`;
     }

--- a/src/lib/LiquidityProviders.svelte
+++ b/src/lib/LiquidityProviders.svelte
@@ -17,7 +17,7 @@
   let loading = true;
   let error = null;
 
-  const API_DOMAIN = import.meta.env.VITE_API_DOMAIN || 'https://thornode-archive.ninerealms.com';
+  const API_DOMAIN = import.meta.env.VITE_API_DOMAIN || 'https://thornode.ninerealms.com';
 
   // Add this store to track the active tab across components
   const activeTabStore = writable('checker');
@@ -95,6 +95,11 @@
 
   // Update the handleGoBack function
   function handleGoBack() {
+    selectedPool = null;
+    selectedAddress = null;
+    selectedBlockHeight = null;
+    addressInput = '';
+    blockHeightInput = '';
     activeTabStore.set('checker');
     updateURL();
     updateTitle(null);
@@ -213,6 +218,11 @@
                 placeholder="Block height (optional)"
                 bind:value={blockHeightInput}
                 min="4786560"
+                on:blur={(e) => {
+                  if (e.target.value && parseInt(e.target.value) < 4786560) {
+                    blockHeightInput = '4786560';
+                  }
+                }}
               />
               <button 
                 on:click={handleDetailSubmit} 


### PR DESCRIPTION
Notes:

1. Minimum block height of 4786560 is as far back as we can go on thornode-archive
2. There is no input validation on the height parameter; a user could enter 123 or some other bogus height and the UI won't stop them. Maybe Claude can recommend a better way of enforcing a minimum using `on:input` or `on:blur`
