### PR TITLE
Fix mobile scroll issue on SolanaProviders

### DIFF
--- a/src/lib/SolanaProviders.svelte
+++ b/src/lib/SolanaProviders.svelte
@@ -705,7 +705,6 @@
     color: #FFFFFF;
     background-color: #1a1a1a;
     min-height: 100vh;
-    overflow-x: hidden;
   }
 
   .app-header {


### PR DESCRIPTION
## Summary
- Remove `overflow-x: hidden` from container that was breaking touch scrolling on Android Chrome

## Test plan
- [x] Test vertical page scrolling works on Android Chrome
- [x] Verify table horizontal scrolling still works within containers