### PR TITLE
Update liquify endpoints to new gateway endpoints

### DIFF
--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -25,7 +25,7 @@ export {
  */
 export const ENDPOINTS = {
   thornode: {
-    liquify: 'https://thornode.thorchain.liquify.com',
+    liquify: 'https://gateway.liquify.com/chain/thorchain_api',
     ninerealms: 'https://thornode.ninerealms.com',
     archive: 'https://thornode-archive.ninerealms.com'
   },

--- a/src/lib/api/thornode.js
+++ b/src/lib/api/thornode.js
@@ -20,7 +20,7 @@ import { fromBaseUnit } from '../utils/blockchain.js';
 export const PROVIDERS = {
   liquify: {
     name: 'liquify',
-    base: 'https://thornode.thorchain.liquify.com',
+    base: 'https://gateway.liquify.com/chain/thorchain_api',
     updateFrequency: 6000, // 6 seconds
     priority: 1
   },

--- a/src/lib/utils/api.js
+++ b/src/lib/utils/api.js
@@ -21,7 +21,7 @@
  * THORNode API endpoints with fallback
  */
 export const THORNODE_ENDPOINTS = {
-  primary: 'https://thornode.thorchain.liquify.com',
+  primary: 'https://gateway.liquify.com/chain/thorchain_api',
   fallback: 'https://thornode.ninerealms.com'
 };
 

--- a/updateIpInfo.js
+++ b/updateIpInfo.js
@@ -9,7 +9,7 @@ const __dirname = path.dirname(__filename);
 
 // THORChain API endpoints
 const API_ENDPOINTS = {
-  primary: 'https://thornode.thorchain.liquify.com',
+  primary: 'https://gateway.liquify.com/chain/thorchain_api',
   fallback: 'https://thornode.ninerealms.com'
 };
 


### PR DESCRIPTION
We are migrating to our new gateway so updating the legacy thorchain liquify API to the new gateway endpoints. 