### PR TITLE
Revamp thornode fetch mechanism, use ThorNodeClient universally

### DIFF
--- a/src/lib/Affiliates.svelte
+++ b/src/lib/Affiliates.svelte
@@ -4,9 +4,8 @@
   import { getInboundAddresses, getExplorerUrl, getOutboundFee } from '$lib/utils/network';
   import { getAllPools } from '$lib/utils/liquidity';
   import { fromBaseUnit } from '$lib/utils/blockchain';
-  import { fetchJSONWithFallback } from '$lib/utils/api';
   import { ErrorDisplay } from '$lib/components';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
   import { getMimirValue } from '$lib/utils/mimir';
 
   interface ThorNameResponse {

--- a/src/lib/BondTracker.svelte
+++ b/src/lib/BondTracker.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from "svelte";
-  import { thornode } from '$lib/api';
-  import { midgard } from '$lib/api/midgard';
+  import { thornode, midgard } from '$lib/api';
   import { formatNumber, simplifyNumber, formatCountdown, getAddressSuffix } from '$lib/utils/formatting';
   import { fromBaseUnit } from '$lib/utils/blockchain';
   import { getChurnInfo, getLastChurn, getNodes, getLeaveStatus, LEAVE_STATUS } from '$lib/utils/nodes';
@@ -173,7 +172,7 @@
 
       // Fetch detailed data for each node
       const nodeDataPromises = nodes.map(async (node) => {
-        const nodeData = await thornode.fetch(`/thorchain/node/${node.address}`);
+        const nodeData = await thornode.getNode(node.address);
         const bondProviders = nodeData.bond_providers.providers;
 
         let userBond = 0;
@@ -249,7 +248,7 @@
     try {
       // Parallelize independent API calls
       const [nodeData, lastChurn, runePriceData, allNodesData] = await Promise.all([
-        thornode.fetch(`/thorchain/node/${node_address}`),
+        thornode.getNode(node_address),
         getLastChurn(),
         thornode.getNetwork(),
         getNodes()

--- a/src/lib/BuyRune.svelte
+++ b/src/lib/BuyRune.svelte
@@ -17,7 +17,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { ethers } from 'ethers';
   import { fade } from 'svelte/transition';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
   
   let account = '';
   let selectedAsset = 'ETH';

--- a/src/lib/Constants.svelte
+++ b/src/lib/Constants.svelte
@@ -17,7 +17,7 @@
   onMount(async () => {
     try {
       const [constantsData, mimirData] = await Promise.all([
-        thornode.fetch('/thorchain/constants'),
+        thornode.getConstants(),
         getAllMimir()
       ]);
 

--- a/src/lib/InboundAddresses.svelte
+++ b/src/lib/InboundAddresses.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { copyToClipboard as copyToClipboardUtil, shortenAddress } from '$lib/utils/formatting';
-  import { fetchJSONWithFallback } from '$lib/utils/api';
+  import { thornode } from '$lib/api';
   import { fromBaseUnit } from '$lib/utils/blockchain';
   import { getAllPools } from '$lib/utils/liquidity';
   import {
@@ -38,7 +38,7 @@
       const [inboundData, poolsData, networkData] = await Promise.all([
         getInboundAddresses(),
         getAllPools(),
-        fetchJSONWithFallback('/thorchain/network')
+        thornode.getNetwork()
       ]);
 
       const runePrice = fromBaseUnit(networkData.rune_price_in_tor);

--- a/src/lib/IncentivePendulum.svelte
+++ b/src/lib/IncentivePendulum.svelte
@@ -34,9 +34,9 @@
   const fetchData = async () => {
     try {
       const [vaultsData, poolsData, nodesData, mimirValues] = await Promise.all([
-        thornode.fetch('/thorchain/vaults/asgard'),
-        thornode.fetch('/thorchain/pools'),
-        thornode.fetch('/thorchain/nodes'),
+        thornode.getVaults(),
+        thornode.getPools(),
+        thornode.getNodes(),
         getMimirValues(['PendulumAssetBasisPoints', 'PendulumUseVaultAssets', 'PendulumUseEffectiveSecurity'])
       ]);
       const { PendulumAssetBasisPoints: mimirData, PendulumUseVaultAssets: pendulumUseVaultAssetsData, PendulumUseEffectiveSecurity: pendulumUseEffectiveSecurityData } = mimirValues;

--- a/src/lib/LPChecker.svelte
+++ b/src/lib/LPChecker.svelte
@@ -7,7 +7,7 @@
   import { fromBaseUnit, getAssetShortName } from '$lib/utils/blockchain';
   import { getLPType, calculateLPValue } from '$lib/utils/liquidity';
   import { getAddressLabel } from '$lib/constants/addresses';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
 
   let pools = [];
   let selectedPool = null;

--- a/src/lib/LPDetail.svelte
+++ b/src/lib/LPDetail.svelte
@@ -5,7 +5,7 @@
   import { calculateLPValue } from '$lib/utils/liquidity';
   import { getAssetLogo } from '$lib/constants/assets';
   import { CopyIcon } from '$lib/components';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
 
   export let address = null;
   export let pool = null;

--- a/src/lib/LendingEstimator.svelte
+++ b/src/lib/LendingEstimator.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from "svelte";
   import { slide } from "svelte/transition";
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
   let fromAsset = "BTC.BTC"; // default collateral asset BTC
   let userFromAmount = ""; // user inputted fromAmount (not yet converted to 1e8)
   let toAsset = "ETH.USDT-0XDAC17F958D2EE523A2206206994597C13D831EC7"; // Asset the user will receive their debt equivalent in (default USDT)

--- a/src/lib/LiquidityCap.svelte
+++ b/src/lib/LiquidityCap.svelte
@@ -30,8 +30,8 @@
     try {
       // Fetch vault data, pools, and TVLCAPBASISPOINTS in parallel
       const [vaults, pools, tvlCapValue] = await Promise.all([
-        thornode.fetch('/thorchain/vaults/asgard'),
-        thornode.fetch('/thorchain/pools'),
+        thornode.getVaults(),
+        thornode.getPools(),
         getMimirValue('TVLCAPBASISPOINTS')
       ]);
 
@@ -76,7 +76,7 @@
       totalVaultValueInRune = vaultAssets.reduce((sum, asset) => sum + asset.runeValue, 0);
 
       // Fetch node data for security budget
-      const nodes = await thornode.fetch('/thorchain/nodes');
+      const nodes = await thornode.getNodes();
 
       // Get active nodes and sort by bond size (largest to smallest)
       const activeNodes = nodes

--- a/src/lib/LiquidityProviders.svelte
+++ b/src/lib/LiquidityProviders.svelte
@@ -5,7 +5,7 @@
   import { writable } from 'svelte/store';
   import { getRunePrice } from '$lib/utils/network';
   import { fromBaseUnit } from '$lib/utils/blockchain';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
   import { ErrorDisplay } from '$lib/components';
 
   let activeTab = 'checker';

--- a/src/lib/OraclePrice.svelte
+++ b/src/lib/OraclePrice.svelte
@@ -2,10 +2,9 @@
   import { onMount } from 'svelte';
   import { writable } from 'svelte/store';
   import { cubicOut } from 'svelte/easing';
-  import { fetchJSONWithFallback } from '$lib/utils/api';
   import { getAllPools } from '$lib/utils/liquidity';
   import { fromBaseUnit } from '$lib/utils/blockchain';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
   import { RefreshIcon } from '$lib/components';
 
   const oraclePrices = writable({});
@@ -160,7 +159,7 @@
   async function fetchOraclePrices() {
     try {
       // Use shared utility with fallback support
-      const data = await fetchJSONWithFallback('/thorchain/oracle/prices');
+      const data = await thornode.getOraclePrices();
       const pricesMap = {};
       data.prices.forEach(item => {
         pricesMap[item.symbol] = parseFloat(item.price);

--- a/src/lib/Orderbooks.svelte
+++ b/src/lib/Orderbooks.svelte
@@ -5,7 +5,7 @@
   import { getRunePrice } from '$lib/utils/network';
   import { fromBaseUnit, normalizeAsset, getAssetType, getChainFromAsset } from '$lib/utils/blockchain';
   import { getPoolDepthUSD } from '$lib/utils/liquidity';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
 
   let limitSwapsSummary = null;
   let limitSwaps = [];

--- a/src/lib/PATTERN-INVENTORY.md
+++ b/src/lib/PATTERN-INVENTORY.md
@@ -155,37 +155,77 @@ const logo = getAssetLogo(pool.asset);
 ### THORNode Client
 
 **Provider Strategy:**
-- **Liquify** (`gateway.liquify.com/chain/thorchain_api`): Updates every 6 seconds - use for real-time data
-- **Nine Realms** (`thornode.ninerealms.com`): Updates ~1 minute - fallback after 3 Liquify failures
-- **Archive** (`thornode-archive.ninerealms.com`): Historical queries with block height
+
+THORNode API providers are defined in array `THORNODE_PROVIDERS`.  Each entry is an object containing multiple attributes:
+
+- `base` (string): base API URL without trailing slash (required)
+- `headers` (object): key/value pair of parameters passed to fetch() (optional)
+- `supportsBlockHeight` (boolean): whether or not API endpoints supports `?height` HTTP parameter (optional, default false)
+
+### Method Options
+
+All THORNode Client methods support an optional `options` object as the last parameter.
+
+This object is passed onto the private method called `#fetch()` which can contain header information (for standard
+JavaScript fetch()) as well keys that act as "control" capabilities for the fetch mechanism itself:
+
+- `cache` (boolean, true): whether or not to cache responses
+- `cacheTTL` (integer, 60000): cache entry time-to-live in milliseconds
+- `blockHeight` (integer|null): block height to query API information for. Only works with `supportsBlockHeight: true` providers
 
 ### Available Methods
 
 | Method | Purpose |
 |--------|---------|
-| `thornode.fetch(path, options)` | Raw fetch with failover |
 | `thornode.getNetwork()` | Get network data (includes RUNE price) |
-| `thornode.getRunePrice()` | Get RUNE price in USD directly |
+| `thornode.getUpgradeProposals()` | Get current upgrade proposals |
+| `thornode.getUpgradeProposal(name)` | Get current upgrade proposals for the provided name |
+| `thornode.getLastBlocks()` | Get last block info for all chains |
+| `thornode.getLastBlock(chain)` | Get last block info for provided chain |
 | `thornode.getPools()` | Get all pools |
 | `thornode.getPool(asset)` | Get specific pool |
 | `thornode.getNodes()` | Get all nodes |
+| `thornode.getNode(address)` | Get node information via address |
 | `thornode.getMimir(key)` | Get Mimir value |
 | `thornode.getAllMimir()` | Get all Mimir values |
+| `thornode.getMimirAllNodeVotes()` | Get all current node Mimir votes |
 | `thornode.getBalance(address)` | Get address balance |
-| `thornode.getLiquidityProvider(pool, address, options)` | Get LP data (supports `{ blockHeight }` for historical) |
+| `thornode.getLiquidityProviders(pool)` | Get all liquidity providers for a pool |
+| `thornode.getLiquidityProvider(pool, address)` | Get liquidity provider data via pool and address |
 | `thornode.getVaults()` | Get Asgard vaults |
 | `thornode.getInboundAddresses()` | Get inbound addresses |
 | `thornode.getConstants()` | Get protocol constants |
+| `thornode.getStatus()` | Get current block status |
 | `thornode.getSwapQuote(params)` | Get swap quote |
+| `thornode.getSaver(asset, address)` | Get saver data for asset and address |
+| `thornode.getSaverWithdrawQuote(params)` | Get saver withdraw quote |
+| `thornode.getThorname(name)` | Get THORName data for name |
+| `thornode.getRunePool()` | Get all RUNE Pool information |
+| `thornode.getRuneProviders()` | Get all RUNE providers |
+| `thornode.getRuneProvider(address)` | Get information for RUNE Provider via address |
+| `thornode.getTxStatus(txid)` | Get transaction status via txid |
+| `thornode.getLoanQuote(params)` | Get loan open quote |
+| `thornode.getLimitSwapsSummary()` | Get limit swaps summary |
+| `thornode.getLimitSwaps(params)` | Get limit swaps |
+| `thornode.getOutboundFees()` | Get all outbound fees |
+| `thornode.getTcyStakers()` | Get all TCY stakers |
+| `thornode.getTcyStaker(address)` | Get TCY staker position details via address |
+| `thornode.getTcyStakeModuleBalance()` | Get TCY stake module balance (accrued RUNE for distribution) |
+| `thornode.getTcyClaimers()` | Get all pending TCY claimants (those who have unclaimed TCY) |
+| `thornode.getTcyTotalSupply()` | Get total TCY supply via CMC data |
+| `thornode.getSupplyByDenomination(denom)` | Get total supply by asset denomination |
+| `thornode.getCosmosBlockByHeight(height)` | Get block details from Cosmos SDK/RPC layer (GetBlockByHeight) |
+| `thornode.getOraclePrices()` | Get all available oracle prices |
+| `thornode.getSecuredAssets()` | Get total size and ratio of all secured assets |
+| `thornode.getSwapperClout(address)` | Get the clout score of an address |
+| `thornode.getTradeUnits()` | Get total units and depth for all Trade Assets |
+| `thornode.getTreasuryInfo()` | Get Treasury module address and assets/balances |
 
 ### Options
 
 ```javascript
 // Default: Uses Liquify with Nine Realms fallback
 await thornode.getNetwork();
-
-// Prefer Nine Realms (less frequent updates OK)
-await thornode.getPools({ preferNinerealms: true });
 
 // Historical query with block height (uses Archive)
 await thornode.getLiquidityProvider(pool, address, { blockHeight: 12345678 });
@@ -211,11 +251,11 @@ const fetchRunePrice = async () => {
 
 **After:**
 ```javascript
-import { thornode } from '$lib/api';
+import { getRunePrice } from '$lib/utils/network';
 
 const fetchRunePrice = async () => {
   try {
-    runePrice = await thornode.getRunePrice();
+    runePrice = await getRunePrice();
   } catch (err) {
     console.error('Failed to fetch RUNE price:', err);
   }
@@ -337,7 +377,7 @@ When migrating a component, check for these patterns:
 - [ ] Hardcoded `1e8` → `THOR_BASE`
 
 ### Replace Direct API Calls
-- [ ] `fetch('https://thornode.ninerealms.com/...')` → `thornode.fetch()` or convenience method
+- [X] `fetch('https://thornode.ninerealms.com/...')` → `thornode.fetch()` or convenience method
 - [ ] `fetch('https://midgard.ninerealms.com/...')` → `midgard.fetch()` or convenience method
 
 ### Replace Independent Data Fetching

--- a/src/lib/RunePool.svelte
+++ b/src/lib/RunePool.svelte
@@ -58,7 +58,7 @@
   });
 
   async function fetchRunepoolData() {
-    const data = await thornode.fetch('/thorchain/runepool');
+    const data = await thornode.getRunePool();
     const providers = data.providers;
 
     value = formatRuneAmount(providers.value / 1e8);
@@ -69,7 +69,7 @@
   }
 
   async function fetchDepositorCount() {
-    const data = await thornode.fetch('/thorchain/rune_providers');
+    const data = await thornode.getRuneProviders();
     depositorCount = data.length;
   }
 
@@ -78,9 +78,9 @@
 
     // Fetch user position, mimir, and last block in parallel
     const [data, mimirData, blockData] = await Promise.all([
-      thornode.fetch(`/thorchain/rune_provider/${address}`),
+      thornode.getRuneProvider(address),
       getAllMimir(),
-      thornode.fetch('/thorchain/lastblock')
+      thornode.getLastBlocks()
     ]);
 
     userValue = formatRuneAmount(data.value / 1e8);
@@ -96,7 +96,7 @@
   }
 
   async function fetchAllPositions() {
-    const data = await thornode.fetch('/thorchain/rune_providers');
+    const data = await thornode.getRuneProviders();
 
     allPositions = data.map((position) => {
       const depositValue = position.deposit_amount / 1e8;
@@ -119,7 +119,7 @@
     try {
         // First get all pools data and mimir in parallel
         const [poolsData, mimirData] = await Promise.all([
-          thornode.fetch('/thorchain/pools'),
+          thornode.getPools(),
           getAllMimir()
         ]);
 
@@ -144,7 +144,7 @@
                 const [chain, ...rest] = asset.split('-');
                 const poolName = `${chain}.${rest.join('-')}`;
 
-                const data = await thornode.fetch(`/thorchain/pool/${poolName}/liquidity_provider/thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt`);
+                const data = await thornode.getLiquidityProvider(poolName, 'thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt');
                 const runeValue = Number(data.rune_redeem_value) / 1e8;
                 
                 // Calculate ownership percentage

--- a/src/lib/SaversPosition.svelte
+++ b/src/lib/SaversPosition.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from "svelte";
   import { copyToClipboard as copyToClipboardUtil } from '$lib/utils/formatting';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
 
   export let asset = "";
   export let address = "";

--- a/src/lib/SaversYield.svelte
+++ b/src/lib/SaversYield.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from "svelte";
   import Chart from "chart.js/auto";
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
   import { getAllMimir } from '$lib/utils/mimir';
 
   let MAXSYNTHSFORSAVERSYIELD;

--- a/src/lib/SecuredAssets.svelte
+++ b/src/lib/SecuredAssets.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { writable } from 'svelte/store';
   import { RefreshIcon, SettingsIcon } from '$lib/components';
-  import { fetchJSONWithFallback } from '$lib/utils/api';
+  import { thornode } from '$lib/api';
 
   const showInUSD = writable(false);
   const showSettings = writable(false);
@@ -12,7 +12,7 @@
   async function getSecuredAssets() {
     try {
       // Use shared utility with fallback support
-      const data = await fetchJSONWithFallback('/thorchain/securedassets');
+      const data = await thornode.getSecuredAssets();
       return data.map(asset => ({
         ...asset,
         supply: Number(asset.supply),

--- a/src/lib/Supply.svelte
+++ b/src/lib/Supply.svelte
@@ -196,7 +196,7 @@
 
   const fetchSupply = async () => {
     try {
-      const data = await thornode.fetch('/cosmos/bank/v1beta1/supply/by_denom?denom=rune');
+      const data = await thornode.getSupplyByDenomination('rune');
       const totalSupplyInRune = fromBaseUnit(data.amount.amount);
       tweenedTotalSupply.set(totalSupplyInRune);
       currentSupply = totalSupplyInRune;

--- a/src/lib/SwapEstimator.svelte
+++ b/src/lib/SwapEstimator.svelte
@@ -6,8 +6,7 @@
         import { slide } from 'svelte/transition';
         import { SettingsIcon } from '$lib/components';
         import AssetDropdown from './SwapEstimator/AssetDropdown.svelte';
-        import { thornode } from '$lib/api/thornode';
-        import { midgard } from '$lib/api/midgard';
+        import { thornode, midgard } from '$lib/api';
   
           
         let amount = null; //random starting swap

--- a/src/lib/TCY.svelte
+++ b/src/lib/TCY.svelte
@@ -9,8 +9,8 @@
     formatUSDWithDecimals
   } from '$lib/utils/formatting';
   import { blocksToSeconds, fromBaseUnit } from '$lib/utils/blockchain';
-  import { fetchJSONWithFallback, THORNODE_ENDPOINTS, MIDGARD_ENDPOINTS } from '$lib/utils/api';
-  import { getRunePrice } from '$lib/utils/network';
+  import { thornode } from '$lib/api';
+  import { getRunePrice, getCurrentBlock } from '$lib/utils/network';
   import {
     getTCYPrice,
     getTCYMimir,
@@ -18,7 +18,6 @@
     getTCYStaker,
     getTCYDistributionHistory,
     getTCYStakeModuleBalance,
-    getCurrentBlock,
     getNextDistributionBlock,
     calculateUserDistributionShare,
     getHistoricalRunePrices,
@@ -166,7 +165,7 @@
 
       // Fetch unstaked balances using shared utility with fallback
       try {
-        const unstakedData = await fetchJSONWithFallback(`/cosmos/bank/v1beta1/balances/${address}`);
+        const unstakedData = await thornode.getBalance(address);
         const tcyBalance = unstakedData.balances.find(b => b.denom === "tcy");
         const runeBalance = unstakedData.balances.find(b => b.denom === "rune");
         unstakedBalance = tcyBalance ? fromBaseUnit(tcyBalance.amount) : 0;

--- a/src/lib/Thorswap.svelte
+++ b/src/lib/Thorswap.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
 
   let assets = [];
   let fromAsset = 'BTC.BTC';

--- a/src/lib/TokenWhitelist.svelte
+++ b/src/lib/TokenWhitelist.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { slide } from 'svelte/transition';
   import { copyToClipboard as copyToClipboardUtil } from '$lib/utils/formatting';
-  import { thornode } from '$lib/api/thornode';
+  import { thornode } from '$lib/api';
 
   interface Pool {
     asset: string;

--- a/src/lib/Treasury.svelte
+++ b/src/lib/Treasury.svelte
@@ -91,7 +91,7 @@
             // Check each asset individually
             for (const asset of LP_ASSETS) {
                 try {
-                    const data = await thornode.fetch(`/thorchain/pool/${encodeURIComponent(asset)}/liquidity_provider/${address}`);
+                    const data = await thornode.getLiquidityProvider(asset, address);
 
                     // Only add if there are actual LP positions (units > 0)
                     if (data.units && Number(data.units) > 0) {
@@ -119,7 +119,7 @@
     async function fetchThorBalances() {
         try {
             // Fetch treasury address first
-            const treasuryData = await thornode.fetch('/thorchain/balance/module/treasury');
+            const treasuryData = await thornode.getTreasuryInfo();
             const treasuryAddress = treasuryData.address;
 
             // Add treasury address to the list if not already present
@@ -139,7 +139,7 @@
             // Use the updated addresses array
             const results = await Promise.all(
                 addresses.map(async ({address, label}) => {
-                    const balanceData = await thornode.fetch(`/cosmos/bank/v1beta1/balances/${address}`);
+                    const balanceData = await thornode.getBalance(address);
                     const lpPositionsData = await fetchLPPositions(address);
 
                     return {
@@ -257,7 +257,7 @@
 
     async function fetchPools() {
         try {
-            const pools = await thornode.fetch('/thorchain/pools');
+            const pools = await thornode.getPools();
 
             // Filter for Available pools only
             LP_ASSETS = pools

--- a/src/lib/TxStatus.svelte
+++ b/src/lib/TxStatus.svelte
@@ -2,8 +2,7 @@
   import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { copyToClipboard as copyToClipboardUtil } from '$lib/utils/formatting';
-  import { thornode } from '$lib/api/thornode';
-  import { midgard } from '$lib/api/midgard';
+  import { thornode, midgard } from '$lib/api';
 
   let txId = '';
   let txData = null;

--- a/src/lib/Vaults.svelte
+++ b/src/lib/Vaults.svelte
@@ -17,7 +17,7 @@
     calculateVaultBond,
     calculateVaultAssetValue
   } from '$lib/utils/network';
-  import { fetchJSONWithFallback } from '$lib/utils/api';
+  import { thornode } from '$lib/api';
   import { fromBaseUnit } from '$lib/utils/blockchain';
   import { getNodes } from '$lib/utils/nodes';
   import { getAssetLogo, getAssetDisplayName } from '$lib/constants';
@@ -47,7 +47,7 @@
 
   async function fetchPrices() {
     try {
-      const pools = await fetchJSONWithFallback('/thorchain/pools');
+      const pools = await thornode.getPools();
 
       const priceMap = pools.reduce((acc, pool) => {
         const assetExistsInVaults = vaults.some(vault =>
@@ -83,7 +83,7 @@
 
   async function fetchNetwork() {
     try {
-      networkData = await fetchJSONWithFallback('/thorchain/network');
+      networkData = await thornode.getNetwork();
     } catch (e) {
       console.error('Error fetching network data:', e);
     }

--- a/src/lib/Version.svelte
+++ b/src/lib/Version.svelte
@@ -83,7 +83,7 @@
 
   async function fetchUpgradeProposal() {
     try {
-      const data = await thornode.fetch('/thorchain/upgrade_proposals', { cache: false });
+      const data = await thornode.getUpgradeProposals({ cache: false });
       
       // Add debugging
       if (data && data[0]) {
@@ -110,7 +110,7 @@
 
   async function fetchUpgradeProposalDetails(name) {
     try {
-      const data = await thornode.fetch(`/thorchain/upgrade_proposal/${name}`, { cache: false });
+      const data = await thornode.getUpgradeProposal(name, { cache: false });
       upgradeProposalDetails = data;
     } catch (error) {
       console.error('Error fetching upgrade proposal details:', error);

--- a/src/lib/api/index.js
+++ b/src/lib/api/index.js
@@ -9,8 +9,7 @@
 export {
   thornode,
   ThorNodeClient,
-  PROVIDERS,
-  THORNODE_ENDPOINTS
+  THORNODE_PROVIDERS
 } from './thornode.js';
 
 // Midgard client
@@ -20,19 +19,3 @@ export {
   MIDGARD_BASE,
   MIDGARD_PROVIDERS
 } from './midgard.js';
-
-/**
- * All endpoint constants for reference
- */
-export const ENDPOINTS = {
-  thornode: {
-    liquify: 'https://gateway.liquify.com/chain/thorchain_api',
-    ninerealms: 'https://thornode.ninerealms.com',
-    archive: 'https://thornode-archive.ninerealms.com'
-  },
-  midgard: {
-    liquify: 'https://gateway.liquify.com/chain/thorchain_midgard/v2',
-    ninerealms: 'https://midgard.ninerealms.com/v2'
-  },
-  coingecko: 'https://api.coingecko.com/api/v3'
-};

--- a/src/lib/api/thornode.js
+++ b/src/lib/api/thornode.js
@@ -1,208 +1,197 @@
 /**
  * THORNode API Client
- *
- * Provider Strategy:
- * - Liquify (gateway.liquify.com/chain/thorchain_api): Updates every 6 seconds (per block)
- *   Use for real-time data like prices, block status, live feeds
- *
- * - Nine Realms (thornode.ninerealms.com): Updates ~once per minute
- *   More stable, use as fallback after Liquify failures
- *
- * - Archive (thornode-archive.ninerealms.com): For historical queries
- *   Use when fetching data at specific block heights
  */
 
 import { fromBaseUnit } from '../utils/blockchain.js';
 
 /**
- * API Provider configurations
+ * THORNode API provider list -- in order of preference
+ *
+ * @typedef {Object} ApiProvider
+ * @property {string} base - THORNode API base URL (no trailing slash)
+ * @property {Record<string, string>} [headers] - HTTP client headers (e.g. x-client-id)
+ * @property {boolean} [supportsBlockHeight] - When true, `?height=` is appended for historical queries
  */
-export const PROVIDERS = {
-  liquify: {
-    name: 'liquify',
+
+export const THORNODE_PROVIDERS = Object.freeze([
+  {
     base: 'https://gateway.liquify.com/chain/thorchain_api',
-    updateFrequency: 6000, // 6 seconds
-    priority: 1
-  },
-  ninerealms: {
-    name: 'ninerealms',
-    base: 'https://thornode.ninerealms.com',
-    headers: { 'x-client-id': 'RuneTools' },
-    updateFrequency: 60000, // ~1 minute
-    priority: 2
-  },
-  archive: {
-    name: 'archive',
-    base: 'https://thornode-archive.ninerealms.com',
-    headers: { 'x-client-id': 'RuneTools' },
+    // Liquify at this present time doesn't allow x-client-id through their CORS configuration
+    // headers: { 'x-client-id': 'RuneTools' },
     supportsBlockHeight: true,
-    priority: 3
-  }
-};
+  },
+  {
+    base: 'https://gateway2.liquify.com/chain/thorchain_api',
+    supportsBlockHeight: true,
+  },
+]);
+
+// ============================================
+// Rate Limit Tracking
+// ============================================
+
+/**
+ * Track rate-limited endpoints so we skip them on subsequent requests.
+ * Key: base URL, Value: timestamp when cooldown expires
+ */
+const rateLimitedUntil = new Map();
+const failureCounts = new Map();
+const RATE_LIMIT_COOLDOWN = 60_000; // 60 seconds
+
+// ============================================
+// Caching
+// ============================================
+
+const apiCache = new Map();
+const DEFAULT_CACHE_TTL = 15_000; // 15 seconds
 
 /**
  * THORNode API Client class
  */
 class ThorNodeClient {
-  constructor() {
-    this.failureCount = {
-      liquify: 0,
-      ninerealms: 0
-    };
-    this.maxFailures = 3;
-    this.rateLimitedUntil = {
-      liquify: 0,
-      ninerealms: 0
-    };
-    this.rateLimitCooldown = 60000; // Skip rate-limited provider for 60s
-    this.cache = new Map();
-    this.cacheTTL = 5000; // 5 seconds default cache
-  }
-
   /**
-   * Select the appropriate provider based on options
-   * @param {Object} options - Request options
-   * @returns {Object} Selected provider config
+   * Fetch from THORNode (private)
+   *
+   * @param {string} path - API endpoint path (e.g. '/thorchain/network')
+   * @param {Object} [options={}] - Combined options object:
+   *        - Behavior modifiers: cache, cacheTTL, blockHeight
+   *        - Anything else gets passed into fetch() directly
+   * @param {boolean} [options.cache=true] - Enable/disable response caching
+   * @param {number} [options.cacheTTL] - Cache duration (milliseconds)
+   * @param {number|null} [options.blockHeight=null] - Query historical state at specific block height
+   * @returns {Promise<Response>} Raw `Response` object from the successful provider
    */
-  selectProvider(options = {}) {
-    const { blockHeight, realtime = true, preferNinerealms = false } = options;
-
-    // Archive required for historical queries with block height
-    if (blockHeight) {
-      return PROVIDERS.archive;
-    }
-
-    // If explicitly preferring Nine Realms (for less frequent updates)
-    if (preferNinerealms) {
-      return PROVIDERS.ninerealms;
-    }
-
-    // For real-time data, prefer Liquify unless it's been failing
-    if (realtime && this.failureCount.liquify < this.maxFailures) {
-      return PROVIDERS.liquify;
-    }
-
-    // Fall back to Nine Realms
-    return PROVIDERS.ninerealms;
-  }
-
-  /**
-   * Clear the cache (useful when you want fresh data)
-   */
-  clearCache() {
-    this.cache.clear();
-  }
-
-  /**
-   * Reset failure counters (useful after a successful request)
-   */
-  resetFailures() {
-    this.failureCount.liquify = 0;
-    this.failureCount.ninerealms = 0;
-  }
-
-  /**
-   * Fetch from THORNode with automatic failover
-   * @param {string} path - API endpoint path (e.g., '/thorchain/network')
-   * @param {Object} options - Fetch options
-   * @returns {Promise<any>} Response data
-   */
-  async fetch(path, options = {}) {
+  async #fetch(path, options = {}) {
     const {
       cache = true,
-      blockHeight,
-      parseJson = true,
-      realtime = true,
-      preferNinerealms = false,
-      ...fetchOptions
+      cacheTTL = DEFAULT_CACHE_TTL,
+      blockHeight = null,
+      ...fetchInit
     } = options;
+    const now = Date.now();
 
-    // Build cache key
-    const cacheKey = `${path}:${blockHeight || 'latest'}`;
-
-    // Check cache first
-    if (cache && this.cache.has(cacheKey)) {
-      const cached = this.cache.get(cacheKey);
-      if (Date.now() - cached.timestamp < this.cacheTTL) {
-        return cached.data;
-      }
-      // Cache expired, remove it
-      this.cache.delete(cacheKey);
+    let effectivePath = path;
+    if (blockHeight != null) {
+      const separator = path.includes('?') ? '&' : '?';
+      const e_blockHeight = encodeURIComponent(blockHeight);
+      effectivePath += `${separator}height=${e_blockHeight}`;
     }
 
-    // Determine providers to try (in order)
-    const now = Date.now();
-    const allProviders = blockHeight
-      ? [PROVIDERS.archive]
-      : preferNinerealms
-        ? [PROVIDERS.ninerealms, PROVIDERS.liquify]
-        : [PROVIDERS.liquify, PROVIDERS.ninerealms];
+    // Lightweight cache lookup
+    if (cache) {
+      const cached = apiCache.get(effectivePath);
+      if (cached) {
+        const age = now - cached.timestamp;
+        if (age < cacheTTL) {
+          return cached.response.clone();
+        } else {
+          apiCache.delete(effectivePath);
+        }
+      }
+    }
 
-    // Skip rate-limited providers (but keep them as last resort)
-    const available = allProviders.filter(p => {
-      const until = this.rateLimitedUntil[p.name];
-      return !until || now >= until;
+    const available = THORNODE_PROVIDERS.filter(p => {
+      const until = rateLimitedUntil.get(p.base) || 0;
+      return until <= now;
     });
-    const providers = available.length > 0 ? available : allProviders;
+    const rateLimited = THORNODE_PROVIDERS.filter(p => {
+      const until = rateLimitedUntil.get(p.base) || 0;
+      return until > now;
+    });
+    const order = [...available, ...rateLimited];
 
     let lastError = null;
 
-    for (const provider of providers) {
+    for (const provider of order) {
       try {
-        let url = `${provider.base}${path}`;
-
-        // Add block height for archive queries
-        if (blockHeight && provider.supportsBlockHeight) {
-          const separator = url.includes('?') ? '&' : '?';
-          url += `${separator}height=${blockHeight}`;
-        }
-
-        const response = await fetch(url, {
-          headers: { ...(provider.headers || {}), ...fetchOptions.headers },
-          ...fetchOptions
-        });
-
-        if (!response.ok) {
-          // Rate limited — set cooldown so we skip this provider immediately
-          if (response.status === 429 && provider.name in this.rateLimitedUntil) {
-            this.rateLimitedUntil[provider.name] = Date.now() + this.rateLimitCooldown;
-            console.warn(`${provider.name} rate limited (429), switching away for ${this.rateLimitCooldown / 1000}s`);
+        const requestPath = (blockHeight != null && provider.supportsBlockHeight)
+          ? effectivePath
+          : path;
+        const url = `${provider.base}${requestPath}`;
+        const fetchOpts = {
+          ...fetchInit,
+          headers: {
+            ...(provider.headers || {}),
+            ...(fetchInit.headers || {})
           }
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        };
+
+        const response = await fetch(url, fetchOpts);
+        if (response.ok) {
+          // Clear rate limit and failure count on success
+          rateLimitedUntil.delete(provider.base);
+          failureCounts.delete(provider.base);
+
+          if (cache) {
+            // Always cache under effectivePath so historical queries are
+            // consistently cached regardless of which provider was used
+            apiCache.set(effectivePath, {
+              timestamp: now,
+              response: response.clone()
+            });
+          }
+          return response;
         }
-
-        const data = parseJson ? await response.json() : await response.text();
-
-        // Cache successful response
-        if (cache) {
-          this.cache.set(cacheKey, { data, timestamp: Date.now() });
+        if (response.status === 429) {
+          rateLimitedUntil.set(provider.base, Date.now() + RATE_LIMIT_COOLDOWN);
+          console.warn(`Rate limited (429) on ${provider.base}, switching away for ${RATE_LIMIT_COOLDOWN / 1000}s`);
         }
-
-        // Reset failure count and rate limit on success
-        if (provider.name in this.failureCount) {
-          this.failureCount[provider.name] = 0;
-          this.rateLimitedUntil[provider.name] = 0;
-        }
-
-        return data;
+        lastError = new Error(`${provider.base} failed: ${response.status}`);
+        console.warn(`Endpoint failed for ${path}: ${lastError.message}`);
       } catch (error) {
-        lastError = error;
-        console.warn(`THORNode fetch failed for ${provider.name}${path}:`, error.message);
-
-        // Increment failure count and apply cooldown on repeated failures
-        // (CORS-blocked 429s show up as "Failed to fetch" in the catch block)
-        if (provider.name in this.failureCount) {
-          this.failureCount[provider.name]++;
-          if (this.failureCount[provider.name] >= this.maxFailures) {
-            this.rateLimitedUntil[provider.name] = Date.now() + this.rateLimitCooldown;
-            console.warn(`${provider.name} failed ${this.failureCount[provider.name]} times, switching away for ${this.rateLimitCooldown / 1000}s`);
-          }
+        // CORS-blocked 429s show up as "Failed to fetch" here
+        const count = (failureCounts.get(provider.base) || 0) + 1;
+        failureCounts.set(provider.base, count);
+        if (count >= 2) {
+          rateLimitedUntil.set(provider.base, Date.now() + RATE_LIMIT_COOLDOWN);
+          console.warn(`${provider.base} failed ${count} times, switching away for ${RATE_LIMIT_COOLDOWN / 1000}s`);
         }
+        lastError = error;
+        console.warn(`Endpoint failed for ${path}: ${error.message}`);
       }
     }
 
-    // All providers failed
-    throw new Error(`All THORNode providers failed for ${path}: ${lastError?.message}`);
+    console.error(`All providers failed for ${path}:`, lastError);
+    throw lastError;
+  }
+
+  // ============================================
+  // Wrapper methods
+  // ============================================
+
+  /**
+   * Fetch and parse JSON response
+   *
+   * @param {string} path - API endpoint path
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>}
+   */
+  async #fetchJSON(path, options = {}) {
+    const response = await this.#fetch(path, options);
+    return response.json();
+  }
+
+  /**
+   * Fetch and return the response body as plain text
+   *
+   * @param {string} path - API endpoint path
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<string>}
+   */
+  async #fetchText(path, options = {}) {
+    const response = await this.#fetch(path, options);
+    return response.text();
+  }
+
+  // ============================================
+  // Cache methods
+  // ============================================
+
+  /**
+   * Clear cache
+   */
+  clearCache() {
+    apiCache.clear();
   }
 
   // ============================================
@@ -210,213 +199,501 @@ class ThorNodeClient {
   // ============================================
 
   /**
-   * Get network data (includes RUNE price)
-   * @param {Object} options - Fetch options
+   * Get network data (includes RUNE price, current block height, etc.)
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getNetwork(options = {}) {
-    return this.fetch('/thorchain/network', options);
+    return this.#fetchJSON('/thorchain/network', options);
   }
 
   /**
-   * Get RUNE price in USD
-   * @param {Object} options - Fetch options
-   * @returns {Promise<number>} RUNE price
+   * Get current upgrade proposals
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
-  async getRunePrice(options = {}) {
-    const network = await this.getNetwork(options);
-    return fromBaseUnit(network.rune_price_in_tor);
+  async getUpgradeProposals(options = {}) {
+    return this.#fetchJSON('/thorchain/upgrade_proposals', options);
+  }
+
+  /**
+   * Get upgrade proposal for the provided name
+   *
+   * @param {string} name - name parameter
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getUpgradeProposal(name, options = {}) {
+    const e_name = encodeURIComponent(name);
+    return this.#fetchJSON(`/thorchain/upgrade_proposal/${name}`, options);
+  }
+
+  /**
+   * Get last block info for all chains
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getLastBlocks(options = {}) {
+    return this.#fetchJSON('/thorchain/lastblock', options);
+  }
+
+  /**
+   * Get last block info for all chains
+   *
+   * @param {string} chain - Chain identifier
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getLastBlock(chain, options = {}) {
+    const e_chain = encodeURIComponent(chain);
+    return this.#fetchJSON(`/thorchain/lastblock/${e_chain}`, options);
   }
 
   /**
    * Get all pools
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getPools(options = {}) {
-    return this.fetch('/thorchain/pools', options);
+    return this.#fetchJSON('/thorchain/pools', options);
   }
 
   /**
    * Get a specific pool
+   *
    * @param {string} asset - Asset identifier
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getPool(asset, options = {}) {
-    return this.fetch(`/thorchain/pool/${encodeURIComponent(asset)}`, options);
+    const e_asset = encodeURIComponent(asset);
+    return this.#fetchJSON(`/thorchain/pool/${e_asset}`, options);
   }
 
   /**
    * Get all nodes
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getNodes(options = {}) {
-    return this.fetch('/thorchain/nodes', options);
+    return this.#fetchJSON('/thorchain/nodes', options);
+  }
+
+  /**
+   * Get node information via address
+   *
+   * @param {string} address - THORChain node address
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getNode(address, options = {}) {
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(`/thorchain/node/${e_address}`, options);
   }
 
   /**
    * Get a Mimir value
+   *
    * @param {string} key - Mimir key name
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getMimir(key, options = {}) {
-    const data = await this.fetch(`/thorchain/mimir/key/${key}`, {
-      parseJson: false,
-      ...options
-    });
-    return data;
+    const e_key = encodeURIComponent(key);
+    return this.#fetchText(`/thorchain/mimir/key/${e_key}`, options);
   }
 
   /**
    * Get all Mimir values
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getAllMimir(options = {}) {
-    return this.fetch('/thorchain/mimir', options);
+    return this.#fetchJSON('/thorchain/mimir', options);
+  }
+
+  /**
+   * Get all current node Mimir votes
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getMimirAllNodeVotes(options = {}) {
+    return this.#fetchJSON('/thorchain/mimir/nodes_all', options);
   }
 
   /**
    * Get balance for an address
+   *
    * @param {string} address - THORChain address
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getBalance(address, options = {}) {
-    return this.fetch(`/cosmos/bank/v1beta1/balances/${address}`, options);
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(
+      `/cosmos/bank/v1beta1/balances/${e_address}`,
+       options
+    );
   }
 
   /**
-   * Get liquidity provider data
+   * Get all liquidity providers for a pool
+   *
+   * @param {string} pool - Pool asset identifier
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getLiquidityProviders(pool, options = {}) {
+    const e_pool = encodeURIComponent(pool);
+    return this.#fetchJSON(
+      `/thorchain/pool/${e_pool}/liquidity_providers`,
+      options
+    );
+  }
+
+  /**
+   * Get liquidity provider data via pool and address
+   *
    * @param {string} pool - Pool asset identifier
    * @param {string} address - LP address
-   * @param {Object} options - Fetch options (can include blockHeight for historical)
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getLiquidityProvider(pool, address, options = {}) {
-    return this.fetch(
-      `/thorchain/pool/${encodeURIComponent(pool)}/liquidity_provider/${address}`,
+    const e_pool = encodeURIComponent(pool);
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(
+      `/thorchain/pool/${e_pool}/liquidity_provider/${e_address}`,
       options
     );
   }
 
   /**
    * Get Asgard vaults
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getVaults(options = {}) {
-    return this.fetch('/thorchain/vaults/asgard', options);
+    return this.#fetchJSON('/thorchain/vaults/asgard', options);
   }
 
   /**
    * Get inbound addresses
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getInboundAddresses(options = {}) {
-    return this.fetch('/thorchain/inbound_addresses', options);
+    return this.#fetchJSON('/thorchain/inbound_addresses', options);
   }
 
   /**
    * Get constants
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getConstants(options = {}) {
-    return this.fetch('/thorchain/constants', options);
+    return this.#fetchJSON('/thorchain/constants', options);
   }
 
   /**
    * Get current block status
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getStatus(options = {}) {
-    return this.fetch('/status', options);
+    return this.#fetchJSON('/status', options);
   }
 
   /**
    * Get swap quote
+   *
    * @param {Object} params - Quote parameters
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getSwapQuote(params, options = {}) {
     const query = new URLSearchParams(params).toString();
-    return this.fetch(`/thorchain/quote/swap?${query}`, options);
+    return this.#fetchJSON(`/thorchain/quote/swap?${query}`, options);
   }
 
   /**
    * Get saver data for a specific asset and address
+   *
    * @param {string} asset - Asset identifier
    * @param {string} address - Saver address
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getSaver(asset, address, options = {}) {
-    return this.fetch(
-      `/thorchain/pool/${encodeURIComponent(asset)}/saver/${address}`,
+    const e_asset = encodeURIComponent(asset);
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(
+      `/thorchain/pool/${e_asset}/saver/${e_address}`,
       options
     );
   }
 
   /**
    * Get saver withdraw quote
+   *
    * @param {Object} params - Quote parameters (asset, address, withdraw_bps)
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getSaverWithdrawQuote(params, options = {}) {
     const query = new URLSearchParams(params).toString();
-    return this.fetch(`/thorchain/quote/saver/withdraw?${query}`, options);
+    return this.#fetchJSON(`/thorchain/quote/saver/withdraw?${query}`, options);
   }
 
   /**
    * Get THORName data
+   *
    * @param {string} name - THORName to look up
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getThorname(name, options = {}) {
-    return this.fetch(`/thorchain/thorname/${encodeURIComponent(name)}`, options);
+    const e_name = encodeURIComponent(name);
+    return this.#fetchJSON(`/thorchain/thorname/${e_name}`, options);
+  }
+
+  /**
+   * Get all RUNE Pool information
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getRunePool(options = {}) {
+    return this.#fetchJSON('/thorchain/runepool', options);
+  }
+
+  /**
+   * Get all RUNE providers
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getRuneProviders(options = {}) {
+    return this.#fetchJSON('/thorchain/rune_providers', options);
+  }
+
+  /**
+   * Get information for RUNE provider via address
+   *
+   * @param {string} address - THORChain wallet address
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getRuneProvider(address, options = {}) {
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(`/thorchain/rune_provider/${e_address}`, options);
   }
 
   /**
    * Get transaction status
+   *
    * @param {string} txid - Transaction ID
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getTxStatus(txid, options = {}) {
-    return this.fetch(`/thorchain/tx/status/${txid}`, options);
+    const e_txid = encodeURIComponent(txid);
+    return this.#fetchJSON(`/thorchain/tx/status/${e_txid}`, options);
   }
 
   /**
    * Get loan open quote
+   *
    * @param {Object} params - Quote parameters (from_asset, amount, to_asset, destination)
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getLoanQuote(params, options = {}) {
     const query = new URLSearchParams(params).toString();
-    return this.fetch(`/thorchain/quote/loan/open?${query}`, options);
+    return this.#fetchJSON(`/thorchain/quote/loan/open?${query}`, options);
   }
 
   /**
    * Get limit swaps summary
-   * @param {Object} options - Fetch options
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getLimitSwapsSummary(options = {}) {
-    return this.fetch('/thorchain/queue/limit_swaps/summary', options);
+    return this.#fetchJSON('/thorchain/queue/limit_swaps/summary', options);
   }
 
   /**
    * Get limit swaps
+   *
    * @param {Object} params - Query parameters (offset, limit, source_asset, target_asset, sort_by, sort_order)
-   * @param {Object} options - Fetch options
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
   async getLimitSwaps(params = {}, options = {}) {
     const query = new URLSearchParams(params).toString();
-    const path = query ? `/thorchain/queue/limit_swaps?${query}` : '/thorchain/queue/limit_swaps';
-    return this.fetch(path, options);
+    const path = query
+      ? `/thorchain/queue/limit_swaps?${query}`
+      : '/thorchain/queue/limit_swaps';
+    return this.#fetchJSON(path, options);
   }
 
   /**
-   * Get all liquidity providers for a pool
-   * @param {string} pool - Pool asset identifier
-   * @param {Object} options - Fetch options
+   * Get all outbound fees
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
    */
-  async getLiquidityProviders(pool, options = {}) {
-    return this.fetch(
-      `/thorchain/pool/${encodeURIComponent(pool)}/liquidity_providers`,
+  async getOutboundFees(options = {}) {
+    return this.#fetchJSON('/thorchain/outbound_fees', options);
+  }
+
+  /**
+   * Get all TCY stakers
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTcyStakers(options = {}) {
+    return this.#fetchJSON('/thorchain/tcy_stakers', options);
+  }
+
+  /**
+   * Get TCY staker position details
+   *
+   * @param {string} address - THORChain wallet address
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTcyStaker(address, options = {}) {
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(`/thorchain/tcy_staker/${e_address}`, options);
+  }
+
+  /**
+   * Get TCY stake module balance (accrued RUNE for distribution)
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTcyStakeModuleBalance(options = {}) {
+    return this.#fetchJSON('/thorchain/balance/module/tcy_stake', options);
+  }
+
+  /**
+   * Get all pending TCY claimants (those who have unclaimed TCY)
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTcyClaimers(options = {}) {
+    return this.#fetchJSON('/thorchain/tcy_claimers', options);
+  }
+
+  /**
+   * Get total TCY supply via CMC data
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTcyTotalSupply(options = {}) {
+    return this.#fetchText('/thorchain/supply/cmc?asset=tcy&type=total', options);
+  }
+
+  /**
+   * Get total supply by asset denomination
+   *
+   * @param {string} denom - asset denomination in lowercase (e.g. "rune")
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getSupplyByDenomination(denom, options = {}) {
+    const e_denom = encodeURIComponent(denom);
+    return this.#fetchJSON(
+      `/cosmos/bank/v1beta1/supply/by_denom?denom=${e_denom}`,
       options
     );
+  }
+
+  /**
+   * Get block details from Cosmos SDK/RPC layer (GetBlockByHeight)
+   *
+   * @param {string} height - block height
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getCosmosBlockByHeight(height, options = {}) {
+    const e_height = encodeURIComponent(height);
+    return this.#fetchJSON(
+      `/cosmos/base/tendermint/v1beta1/blocks/${e_height}`,
+      options
+    );
+  }
+
+  /**
+   * Get all available oracle prices
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getOraclePrices(options = {}) {
+    return this.#fetchJSON('/thorchain/oracle/prices', options);
+  }
+
+  /**
+   * Get total size and ratio of all secured assets
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getSecuredAssets(options = {}) {
+    return this.#fetchJSON('/thorchain/securedassets', options);
+  }
+
+  /**
+   * Get the clout score of an address
+   *
+   * @param {string} address - wallet address
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getSwapperClout(address, options = {}) {
+    const e_address = encodeURIComponent(address);
+    return this.#fetchJSON(
+      `/thorchain/clout/swap/${e_address}`,
+      options
+    );
+  }
+
+  /**
+   * Get total units and depth for all Trade Assets
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTradeUnits(options = {}) {
+    return this.#fetchJSON('/thorchain/trade/units', options);
+  }
+
+  /**
+   * Get Treasury module address and assets/balances
+   *
+   * @param {Object} [options={}] - Same options as #fetch
+   * @returns {Promise<Object>} Parsed network data
+   */
+  async getTreasuryInfo(options = {}) {
+    return this.#fetchJSON('/thorchain/balance/module/treasury', options);
   }
 }
 
@@ -425,10 +702,3 @@ export const thornode = new ThorNodeClient();
 
 // Export class for testing or custom instances
 export { ThorNodeClient };
-
-// Export provider endpoints for direct use if needed
-export const THORNODE_ENDPOINTS = {
-  liquify: PROVIDERS.liquify.base,
-  ninerealms: PROVIDERS.ninerealms.base,
-  archive: PROVIDERS.archive.base
-};

--- a/src/lib/stores/pools.js
+++ b/src/lib/stores/pools.js
@@ -6,7 +6,7 @@
  */
 
 import { writable, derived, get } from 'svelte/store';
-import { thornode } from '../api/thornode.js';
+import { thornode } from '$lib/api';
 import { fromBaseUnit } from '../utils/blockchain.js';
 
 // Private state for lifecycle management
@@ -101,7 +101,7 @@ export const poolsWithPrices = derived(pools, ($pools) =>
  */
 async function fetchPools() {
   try {
-    const data = await thornode.getPools({ realtime: false, preferNinerealms: true });
+    const data = await thornode.getPools();
 
     pools.set(data);
     poolsLastUpdate.set(new Date());

--- a/src/lib/stores/runePrice.js
+++ b/src/lib/stores/runePrice.js
@@ -7,7 +7,7 @@
  */
 
 import { writable, derived, get } from 'svelte/store';
-import { thornode } from '../api/thornode.js';
+import { getRunePrice } from '$lib/utils/network';
 
 // Private state for lifecycle management
 let updateInterval = null;
@@ -80,7 +80,7 @@ export const runePriceChange = derived(runePriceHistory, ($history) => {
  */
 async function fetchRunePrice() {
   try {
-    const price = await thornode.getRunePrice({ realtime: true });
+    const price = await getRunePrice();
 
     runePrice.set(price);
     runePriceLastUpdate.set(new Date());

--- a/src/lib/utils/liquidity.js
+++ b/src/lib/utils/liquidity.js
@@ -30,7 +30,7 @@
  * console.log(`Profit: ${value.profitPercentage.toFixed(2)}%`);
  */
 
-import { thornode } from '../api/thornode.js';
+import { thornode } from '$lib/api';
 import { fromBaseUnit, parseAsset } from './blockchain.js';
 
 // ============================================
@@ -717,7 +717,7 @@ export function isAsymmetricLP(position) {
  */
 export async function getTradeUnits(options = {}) {
   try {
-    return await thornode.fetch('/thorchain/trade/units', options);
+    return await thornode.getTradeUnits(options);
   } catch (error) {
     console.error('Failed to fetch trade units:', error);
     return [];

--- a/src/lib/utils/mimir.js
+++ b/src/lib/utils/mimir.js
@@ -19,7 +19,7 @@
  * const allValues = await getAllMimir();
  */
 
-import { thornode } from '../api/thornode.js';
+import { thornode } from '$lib/api';
 
 let cache = null;
 let cacheUpperMap = null; // uppercase key -> original key mapping

--- a/src/lib/utils/network.js
+++ b/src/lib/utils/network.js
@@ -28,7 +28,7 @@
  * const explorerUrl = getExplorerUrl('BTC', 'bc1q...');
  */
 
-import { fetchJSONWithFallback } from './api.js';
+import { thornode } from '$lib/api';
 import { fromBaseUnit } from './blockchain.js';
 
 // ============================================
@@ -136,7 +136,7 @@ export async function getInboundAddresses(options = {}) {
     return inboundAddressesCache;
   }
 
-  const data = await fetchJSONWithFallback('/thorchain/inbound_addresses');
+  const data = await thornode.getInboundAddresses();
   inboundAddressesCache = data;
   inboundAddressesCacheTime = now;
 
@@ -243,7 +243,7 @@ export async function getActiveChains() {
  * // Returns: [{ asset: 'BTC.BTC', outbound_fee: '30000', ... }, ...]
  */
 export async function getOutboundFees() {
-  return fetchJSONWithFallback('/thorchain/outbound_fees');
+  return await thornode.getOutboundFees();
 }
 
 /**
@@ -692,7 +692,7 @@ export const VAULT_STATUS = {
  * console.log(`Found ${vaults.length} vaults`);
  */
 export async function getAsgardVaults() {
-  return fetchJSONWithFallback('/thorchain/vaults/asgard');
+  return await thornode.getVaults();
 }
 
 /**
@@ -922,16 +922,28 @@ export function calculateVaultSurplus(vaultBalance, poolBalance, tradeDepth = 0)
  */
 export async function getCurrentBlock() {
   try {
-    const data = await fetchJSONWithFallback('/thorchain/lastblock');
-    if (Array.isArray(data) && data.length > 0) {
-      const height = Number(data[0]?.thorchain);
-      if (height > 0) return height;
+    const data = await thornode.getLastBlocks();
+    if (!Array.isArray(data) || data.length === 0) {
+      console.error('Unexpected /lastblock response: not an array or empty');
+      return 0;
     }
-  } catch (e) {
-    console.error('Error fetching current block:', e);
+    // Find THORChain block from the response (use any chain as reference)
+    const entry = data.find(item => item && 'thorchain' in item);
+    if (!entry || entry.thorchain == null) {
+      console.warn('No entry with thorchain key found in /lastblock; assuming 0)');
+      return 0;
+    }
+    const raw = entry.thorchain;
+    const block = Number(raw);
+    if (isNaN(block) || block <= 0) {
+      console.warn(`Unexpected thorchain height: ${raw} (type: ${typeof raw})`);
+      return 0;
+    }
+    return block;
+  } catch (error) {
+    console.error('Error fetching current block:', error);
+    return 0;
   }
-
-  return 0;
 }
 
 /**
@@ -968,8 +980,8 @@ export async function getSecondsPerBlock(sampleSize = 10, options = {}) {
 
     // Fetch block timestamps for current and (current - sampleSize)
     const [newestBlock, oldestBlock] = await Promise.all([
-      fetchJSONWithFallback(`/cosmos/base/tendermint/v1beta1/blocks/${currentHeight}`, fetchOptions),
-      fetchJSONWithFallback(`/cosmos/base/tendermint/v1beta1/blocks/${currentHeight - sampleSize}`, fetchOptions)
+      thornode.getCosmosBlockByHeight(currentHeight, fetchOptions),
+      thornode.getCosmosBlockByHeight(currentHeight - sampleSize, fetchOptions)
     ]);
 
     const newestTime = newestBlock?.block?.header?.time;
@@ -1014,7 +1026,7 @@ export async function getSecondsPerBlock(sampleSize = 10, options = {}) {
  */
 export async function getRunePrice() {
   try {
-    const networkData = await fetchJSONWithFallback('/thorchain/network');
+    const networkData = await thornode.getNetwork();
     return fromBaseUnit(networkData.rune_price_in_tor);
   } catch (error) {
     console.error('Error fetching RUNE price:', error);
@@ -1047,7 +1059,7 @@ export async function getSwapperClout(address) {
     throw new Error('Address is required');
   }
 
-  return await fetchJSONWithFallback(`/thorchain/clout/swap/${address}`);
+  return await thornode.getSwapperClout(address);
 }
 
 /**

--- a/src/lib/utils/nodes.js
+++ b/src/lib/utils/nodes.js
@@ -23,8 +23,7 @@
  * console.log(`Total bonded: $${totalUSD.toLocaleString()}`);
  */
 
-import { thornode } from '../api/thornode.js';
-import { midgard } from '../api/midgard.js';
+import { thornode, midgard } from '$lib/api';
 import { getMimirValue } from './mimir.js';
 import { fromBaseUnit } from './blockchain.js';
 import { getAddressSuffix } from './formatting.js';
@@ -599,7 +598,7 @@ export async function getNextChurnHeight(options = {}) {
 
   // Try to get next churn height from network endpoint
   try {
-    const networkData = await thornode.fetch('/thorchain/network', options);
+    const networkData = await thornode.getNetwork(options);
     const candidates = ['next_churn_height', 'churn_height', 'churnHeight', 'nextChurnHeight'];
 
     for (const key of candidates) {
@@ -676,7 +675,7 @@ export async function getChurnState(options = {}) {
   // Mimir values served from shared 5-min cache — no extra HTTP requests
   const [churnsData, networkData, churnInterval, haltChurning, currentHeight] = await Promise.all([
     recentChurnsLimit > 0 ? getRecentChurns(recentChurnsLimit, fetchOptions) : getLastChurn(fetchOptions),
-    thornode.fetch('/thorchain/network', fetchOptions).catch(() => null),
+    thornode.getNetwork(fetchOptions).catch(() => null),
     getMimirValue('CHURNINTERVAL').catch(() => 43200),
     getMimirValue('HALTCHURNING').catch(() => 0),
     getCurrentBlock()

--- a/src/lib/utils/tcy.js
+++ b/src/lib/utils/tcy.js
@@ -13,12 +13,11 @@
  * const staker = await getTCYStaker('thor1...');
  */
 
-import { fetchJSONWithFallback, THORNODE_ENDPOINTS, MIDGARD_ENDPOINTS } from './api.js';
+import { fetchJSONWithFallback, MIDGARD_ENDPOINTS } from './api.js';
 import { getAllMimir } from './mimir.js';
 import { fromBaseUnit } from './blockchain.js';
-// Import general network functions and re-export for backwards compatibility
-import { getRunePrice, getCurrentBlock } from './network.js';
-export { getRunePrice, getCurrentBlock };
+import { thornode } from '$lib/api';
+import { getRunePrice, getCurrentBlock } from '$lib/utils/network';
 
 // ============================================
 // Constants
@@ -80,7 +79,7 @@ export const TCY_CONSTANT_KEYS = [
  */
 export async function getTCYPrice() {
   try {
-    const poolsData = await fetchJSONWithFallback('/thorchain/pools');
+    const poolsData = await thornode.getPools();
     const tcyPool = poolsData.find(pool => pool.asset === TCY_ASSET);
     if (tcyPool) {
       return fromBaseUnit(tcyPool.asset_tor_price);
@@ -127,7 +126,7 @@ export async function getPrices() {
  */
 export async function getTCYPool() {
   try {
-    const poolsData = await fetchJSONWithFallback('/thorchain/pools');
+    const poolsData = await thornode.getPools();
     const tcyPool = poolsData.find(pool => pool.asset === TCY_ASSET);
 
     if (!tcyPool) return null;
@@ -174,7 +173,7 @@ export async function getTCYLiquidity() {
  */
 export async function getTCYStakers() {
   try {
-    const data = await fetchJSONWithFallback('/thorchain/tcy_stakers');
+    const data = await thornode.getTcyStakers();
     if (!data.tcy_stakers) return [];
 
     return data.tcy_stakers.map(staker => ({
@@ -203,7 +202,7 @@ export async function getTCYStaker(address) {
   if (!address) return null;
 
   try {
-    const data = await fetchJSONWithFallback(`/thorchain/tcy_staker/${address}`);
+    const data = await thornode.getTcyStaker(address);
     return {
       address: data.address || address,
       amount: fromBaseUnit(data.amount)
@@ -299,7 +298,7 @@ export async function getTCYMimir() {
  */
 export async function getTCYConstants() {
   try {
-    const constantsData = await fetchJSONWithFallback('/thorchain/constants');
+    const constantsData = await thornode.getConstants();
 
     return {
       MinRuneForTCYStakeDistribution: fromBaseUnit(constantsData.int_64_values?.MinRuneForTCYStakeDistribution),
@@ -393,7 +392,7 @@ export async function getTCYDistributionHistory(address) {
  */
 export async function getTCYStakeModuleBalance() {
   try {
-    const data = await fetchJSONWithFallback('/thorchain/balance/module/tcy_stake');
+    const data = await thornode.getTcyStakeModuleBalance();
 
     const runeBalance = data.coins?.find(c => c.denom === 'rune');
     const tcyBalance = data.coins?.find(c => c.denom === 'tcy');
@@ -423,7 +422,7 @@ export async function getTCYStakeModuleBalance() {
  */
 export async function getTCYClaimers() {
   try {
-    const data = await fetchJSONWithFallback('/thorchain/tcy_claimers');
+    const data = await thornode.getTcyClaimers();
     if (!data.tcy_claimers) return [];
 
     return data.tcy_claimers.map(claimer => ({
@@ -467,10 +466,7 @@ export async function getRemainingClaimAddresses() {
  */
 export async function getTCYTotalSupply() {
   try {
-    const response = await fetch('https://api.ninerealms.com/thorchain/supply/cmc?asset=tcy&type=total', {
-      headers: { 'x-client-id': 'RuneTools' }
-    });
-    const supply = await response.json();
+    const supply = await thornode.getTcyTotalSupply();
     return Number(supply) || TCY_TOTAL_SUPPLY;
   } catch (error) {
     console.error('Error fetching TCY total supply:', error);
@@ -512,7 +508,7 @@ export async function getTCYMarketCap() {
 export async function getRuneSupplyAndMarketCap() {
   try {
     const [data, price] = await Promise.all([
-      fetchJSONWithFallback('/cosmos/bank/v1beta1/supply/by_denom?denom=rune'),
+      thornode.getSupplyByDenomination('rune'),
       getRunePrice()
     ]);
 
@@ -544,7 +540,6 @@ export async function getRuneSupplyAndMarketCap() {
  * const block = await getCurrentBlock();
  * console.log(`Current block: ${block}`);
  */
-// getCurrentBlock is now imported from network.js and re-exported above
 
 /**
  * Calculate next distribution block

--- a/src/lib/utils/voting.js
+++ b/src/lib/utils/voting.js
@@ -21,7 +21,7 @@
  * // Returns hex color based on ranking
  */
 
-import { fetchJSONWithFallback } from './api';
+import { thornode } from '$lib/api';
 import { getAllMimir } from './mimir';
 import { getAddressSuffix } from './formatting';
 
@@ -101,7 +101,7 @@ export const VOTE_COLOR_PALETTE = [
  * console.log(`Total votes: ${mimirs.length}`);
  */
 export async function fetchMimirNodeVotes(options = {}) {
-  const data = await fetchJSONWithFallback('/thorchain/mimir/nodes_all', options);
+  const data = await thornode.getMimirAllNodeVotes(options);
   return data.mimirs || [];
 }
 

--- a/src/lib/utils/wallet.js
+++ b/src/lib/utils/wallet.js
@@ -29,7 +29,7 @@
  * const totalUSD = calculateWalletValue(balances, assetPrices, runePrice);
  */
 
-import { thornode } from '../api/thornode.js';
+import { thornode } from '$lib/api';
 import { fromBaseUnit } from './blockchain.js';
 
 // ============================================
@@ -109,7 +109,6 @@ export function assetToDenom(asset) {
  * @param {string} address - THORChain address (thor1...)
  * @param {Object} [options={}] - Fetch options passed to thornode client
  * @param {boolean} [options.cache=true] - Whether to use cached data
- * @param {boolean} [options.realtime=true] - Use realtime provider
  * @returns {Promise<Array<Object>>} Array of balance objects
  *
  * @example


### PR DESCRIPTION
A lot of work went into this -- almost all by hand.  Grok helped with guidelines/recommendations but the rest was human.

I'll work on Midgard next, then Svelte/Vite adjustments (very minor), followed by stuff in the Checklist.

## Before approving and merging this, please be aware of the below!

The "Churn Countdown" feature appeared to be broken prior to this work.  I believe it now works, however the data shown now differs from the original code.  It's hard for me to tell what is/isn't correct.  After I added some logging to the original, as well as this version, I was able to determine the following:

### Original

```
thornode fetch() path = /thorchain/network
thornode.js:121 thornode fetch() options = {cache: false}
thornode.js:120 thornode fetch() path = /thorchain/mimir
thornode.js:121 thornode fetch() options = {}
thornode.js:120 thornode fetch() path = /thorchain/mimir
thornode.js:121 thornode fetch() options = {}
```

Note: `/thorchain/lastblock` DOES get fetched according to DevTools Network tab, but there are tons of errors/warnings about broken options handling in thornode.fetch().

### New (fixed?)

```
thornode fetch() path = /thorchain/network
thornode.js:74 thornode fetch() options = {cache: false}
thornode.js:73 thornode fetch() path = /thorchain/mimir
thornode.js:74 thornode fetch() options = {}
thornode.js:73 thornode fetch() path = /thorchain/mimir
thornode.js:74 thornode fetch() options = {}
thornode.js:73 thornode fetch() path = /thorchain/lastblock
thornode.js:74 thornode fetch() options = {}
thornode.js:73 thornode fetch() path = /cosmos/base/tendermint/v1beta1/blocks/25719541
thornode.js:74 thornode fetch() options = {cache: false}
thornode.js:73 thornode fetch() path = /cosmos/base/tendermint/v1beta1/blocks/25719531
thornode.js:74 thornode fetch() options = {cache: false}
```
