### PR TITLE
Fix decimal point display in TCY

### DIFF
--- a/public/ip-info.json
+++ b/public/ip-info.json
@@ -19,6 +19,10 @@
     "isp": "Amazon Technologies Inc.",
     "countryCode": "US"
   },
+  "5.10.251.12": {
+    "isp": "firstcolo GmbH",
+    "countryCode": "DE"
+  },
   "5.39.12.176": {
     "isp": "OVH SAS",
     "countryCode": "FR"
@@ -930,6 +934,10 @@
   "185.200.244.90": {
     "isp": "LifeinCloud LTD",
     "countryCode": "FR"
+  },
+  "185.200.244.206": {
+    "isp": "LifeinCloud LTD",
+    "countryCode": "GB"
   },
   "185.246.190.93": {
     "isp": "FlokiNET ehf",

--- a/src/lib/TCY.svelte
+++ b/src/lib/TCY.svelte
@@ -227,7 +227,7 @@
   };
 
   // Use shared formatNumber utility with locale formatting
-  const numFormat = (x) => formatNumber(x, { maximumFractionDigits: 1 });
+  const numFormat = (x, decimals=1) => formatNumber(x, { maximumFractionDigits: decimals });
 
   // Use shared formatUSDWithDecimals utility
   const formatCurrency = (value) => formatUSDWithDecimals(value, 2);
@@ -269,11 +269,11 @@
   const formatRuneAmount = (amount) => {
     const value = Number(amount) / 1e8;
     if (value >= 1) {
-      return numFormat(value.toFixed(1));
+      return numFormat(value.toFixed(1), 1);
     } else if (value >= 0.01) {
-      return numFormat(value.toFixed(3));
+      return numFormat(value.toFixed(3), 3);
     } else {
-      return numFormat(value.toFixed(8));
+      return numFormat(value.toFixed(8), 8);
     }
   };
 


### PR DESCRIPTION
numFormat() arrow function should support max decimals, passed to formatNumber().

Without this fix, small numbers like 0.00725404 appear as 0, which is misleading.
